### PR TITLE
Clarified charter on ties in board elections

### DIFF
--- a/_pages/charter.md
+++ b/_pages/charter.md
@@ -40,7 +40,7 @@ In addition, one board member is designated the “outreach board member”. The
 
 Anyone who has participated in (attended, helped, taught, organized, or sponsored) a UF Carpentries workshop in the prior 2 years will be eligible to vote. An election manager will be identified by the board to maintain the eligible voter list, notify voters, and tally votes.
 
-The board administrating the election will select the six ordinary candidates who received the largest number of votes and the one outreach candidate who received the largest number of votes to constitute the next board. In case of ties, up to nine candidates may be selected to constitute the next board. The board administrating the election may use any method to choose between tied candidates to ensure that no more than nine candidates are selected to constitute the next board. The board administrating the election cannot be dissolved until the list of members of the next board has been agreed to by ⅔ of board members and has been published to the UF Carpentries website.
+The board administrating the election will select the six non-outreach candidates who received the largest number of votes and the one outreach candidate who received the largest number of votes to constitute the next board. In case of ties, up to nine candidates may be selected to constitute the next board. The board administrating the election may use any method to choose among tied candidates to ensure that no more than nine candidates are selected to constitute the next board. The board administrating the election cannot be dissolved until the list of members of the next board has been agreed to by ⅔ of board members and has been published to the UF Carpentries website.
 
 ## Amendments to the Charter
 

--- a/_pages/charter.md
+++ b/_pages/charter.md
@@ -40,6 +40,8 @@ In addition, one board member is designated the “outreach board member”. The
 
 Anyone who has participated in (attended, helped, taught, organized, or sponsored) a UF Carpentries workshop in the prior 2 years will be eligible to vote. An election manager will be identified by the board to maintain the eligible voter list, notify voters, and tally votes.
 
+The board administrating the election will select the six ordinary candidates who received the largest number of votes and the one outreach candidate who received the largest number of votes to constitute the next board. In case of ties, up to nine candidates may be selected to constitute the next board. The board administrating the election may use any method to choose between tied candidates to ensure that no more than nine candidates are selected to constitute the next board. The board administrating the election cannot be dissolved until the list of members of the next board has been agreed to by ⅔ of board members and has been published to the UF Carpentries website.
+
 ## Amendments to the Charter
 
 Amendments to the charter can be proposed by existing board members in writing in advance of any board meeting. Amendments require a ⅔ majority vote to be accepted.


### PR DESCRIPTION
The overall algorithm should be:
- The six ordinary members and one outreach member receiving the largest number of votes will be selected to constitute the next board.
- In case of ties, up to nine members may be selected to constitute the next board.
- If more than nine members would be selected, the board administrating the election may use any method to choose between tied candidate to ensure that the next board has nine members or fewer.

**Do not merge**: changes to the charter cannot be made until after the board has voted on it. Contributions to this pull request are welcome until December 11, 2018, when the board will vote on whether or not to incorporate this change into the charter. A 2/3rd vote of the board is necessary for this change to be incorporated.

Closes UF-Carpentry/Coordination#61.