### PR TITLE
Posted results of travel awards for fall 2018

### DIFF
--- a/_posts/2018-12-05-travel-awards-fall-2018.md
+++ b/_posts/2018-12-05-travel-awards-fall-2018.md
@@ -1,0 +1,13 @@
+---
+layout: posts
+title: "Travel Awards for Fall 2018"
+date: 2018-12-05
+---
+
+We are pleased to announce that Punam S. Amratia and Justin J. Millar were awarded [travel awards](/awards/) for fall 2018.
+
+Punam told us, "I attended the American Society of Tropical Medicine and Hygiene Annual Meeting in New Orleans, Louisiana. My poster was entitled "Impact of GPS displacement and sample size on local malaria risk maps of malaria". The conference went great! There was lots of interest in quantifying bias that is incorporated in many survey settings by displacement of GPS data. It is commonly done in national household surveys where sensitive health data is collated but can have drastic implications for geostatistical models designed to create high-resolution predictions for local malaria work."
+
+Justin told us, "I also attended  the American Society of Tropical Medicine and Hygiene Annual Meeting in New Orleans, Louisiana. My poster was entitled "Assessing and projecting the role of distance from local health facilities on early childhood malaria prevalence: a case example from northern Ghana" accessible at [https://jjmillar.shinyapps.io/byd-health-facilities/](https://jjmillar.shinyapps.io/byd-health-facilities/). The conference went really well! This research is part of a collaboration with the Noguchi Institute at the University of Ghana, and the conference is really our only opportunity to meet with our Ghanaian collaborators face-to-face. I’ve also been integrate some new open-access data from different universities and institutes, and it was really great to meet some of the people who work on these things directly and show them how I have implemented their data."
+
+We would like to thank all applicants -- please do apply again next year!

--- a/_posts/2018-12-05-travel-awards-fall-2018.md
+++ b/_posts/2018-12-05-travel-awards-fall-2018.md
@@ -2,6 +2,7 @@
 layout: posts
 title: "Travel Awards for Fall 2018"
 date: 2018-12-05
+excerpt: We announce the winners of the 2018 Fall Travel Awards and where they travelled.
 ---
 
 We are pleased to announce that Punam S. Amratia and Justin J. Millar were awarded [travel awards](/awards/) for fall 2018.

--- a/_posts/2018-12-05-travel-awards-fall-2018.md
+++ b/_posts/2018-12-05-travel-awards-fall-2018.md
@@ -2,7 +2,7 @@
 layout: posts
 title: "Travel Awards for Fall 2018"
 date: 2018-12-05
-excerpt: We announce the winners of the 2018 Fall Travel Awards and where they travelled.
+excerpt: "We announce the winners of the 2018 Fall Travel Awards and where they travelled."
 ---
 
 We are pleased to announce that Punam S. Amratia and Justin J. Millar were awarded [travel awards](/awards/) for fall 2018.


### PR DESCRIPTION
This PR creates a new blog post announcing the recipients of the travel awards for fall 2018.