### PR TITLE
Add minutes from Dec 11 board meeting

### DIFF
--- a/_minutes/Board-2018-12-11.md
+++ b/_minutes/Board-2018-12-11.md
@@ -1,0 +1,100 @@
+---
+layout: single
+title: "2018-12-11 Board Meeting"
+menu: "main"
+date: 2018-12-11
+excerpt: "Election tie decision, next semester workshops, waitlist management"
+---
+
+### Action items
+* 
+
+## Attendees
+Board members: Hao, Brian, Joe, Gaurav, Kristina (remote)
+Non-board members: Matt
+
+## Agenda
+* introductions
+* approve last week's minutes
+* vote on charter amendment to handle election ties
+* status of website updates
+* status of slack creation
+* status of instructor training
+* status of next semester workshops
+  - fix date for February workshop
+* status of off-site workshops program
+* selection of new secretary
+* other issues on coordination github
+  - repo organization
+  - waitlist management and sponsoring departments
+
+## Notes
+* Confirm that April is a possibility for instructor training with Maneesha (Kristina)
+* Get a date and room settled with Flora for regular spring workshop (Brian)
+* Set up a time to meet with IFAS contact (Simona & Geraldine)
+* Meet with DSI president to coordinate activities (Joe)
+
+### Last week's minutes
+* Approved; most saw the PR for that
+
+### Election ties amendment
+* Initially couldn't vote for this because only five board members were present
+* Geraldine sent an email to confirm a yes vote
+* Rest of attendees (Hao, Brian, Joe, Gaurav, Kristina) also voted yes
+* See [this PR](https://github.com/UF-Carpentry/website/pull/20/commits) for amendment language
+
+### Website updates
+* The website tabs have been consolidated
+
+### Slack
+* Everyone has been invited (except Matt)
+* Keep announcing board meetings and elections on email
+* All other discussion should be on Slack or GH issues
+
+### Instructor training
+* Maneesha is in touch with instructors, but likely won't confirm date until early January
+* She asked to extend possible date range to April, which Kristina will confirm is acceptable
+
+### Instructor trainer training
+* This is a remote training to become a trainer of Carpentries instructors
+* Starts in January
+* Applications are due Dec 12
+* See more [here](https://carpentries.org/blog/2018/11/trainer-applications/)
+
+### Next semester workshops
+* There's a lot more traffic on campus Monday and Wednesday according to the recent traffic assessment, so Thursday and Friday might be better
+* Brian will contact Flora to reserve the Informatics room for Feb 7-8
+* Geraldine is having meeting next week about EPI workshop with Taylor
+* Simona was not present for off-site workshop discussion
+* Simona and Geraldine will contact Jeanna M about setting up a Zoom meeting to get travel support for instructors for off-site workshops; hoping to get IFAS on board early; see [GH issue](https://github.com/UF-Carpentry/Coordination/issues/71)
+
+### Next meeting
+* Will be Jan 8
+* Brian offered to take over secretary position from Kristina for Jan 8 and 22 meetings
+* Gaurav offered to do chair position after Hao's run is over, would be for Jan 22 and Feb 5
+
+### GH organization 
+* See [GH issue]()
+
+### Waitlist management
+* Currently Matt has a Google doc where he retains people who contact him about workshops that are full. He doesn't tell people there's a waitlist until they contact him. If they don't sign up for the next workshop, he removes them from the list. 
+* Departments have given us money, they're supposed to have some number of spots
+* Open up registration to those departments early
+* What to do if that takes up all the spots for a workshop
+* Email that we have six slots, then get departments to fill them
+* Get names, either use first six or use lottery, send registration link to each of them
+* Need to keep track of who registers
+* Workshop organizer does this
+* Brian will draw a flow chart or diagram of this process
+
+### Library internship
+* Wait until Dan contacts
+
+### Finances
+* Matt has talked to Geraldine about budget, pretty solid
+* Started to talk about club membership with Carpentries organization
+* Will put budget into club repo, hopefully automate some of it in a script (is currently in Google spreadsheets)
+
+### Other org coordination
+* Joe with meet with new DSI president about coordinating with them
+* Maybe not necessary to coordinate with any groups? Each group is fulfilling some demands of the campus

--- a/_minutes/Board-2018-12-11.md
+++ b/_minutes/Board-2018-12-11.md
@@ -74,7 +74,7 @@ Non-board members: Matt
 * Gaurav offered to do chair position after Hao's run is over, would be for Jan 22 and Feb 5
 
 ### GH organization 
-* See [GH issue]()
+* See [GH issue](https://github.com/UF-Carpentry/Coordination/issues/68)
 
 ### Waitlist management
 * Currently Matt has a Google doc where he retains people who contact him about workshops that are full. He doesn't tell people there's a waitlist until they contact him. If they don't sign up for the next workshop, he removes them from the list. 


### PR DESCRIPTION
The only thing that isn't included in these minutes is a link to wherever the organization of our GitHub repos was being discussed, because I couldn't find it. 