### PR TITLE
Updated prev minutes as requested in board meeting

### DIFF
--- a/_minutes/Board-2019-01-08.md
+++ b/_minutes/Board-2019-01-08.md
@@ -63,10 +63,13 @@ We decided on a detailed solution summarized in [this issue comment](https://git
 
 ### off-site workshops planning
 * Simona is planning a workshop at Homestead this semester.
-* Geraldine will contact Gina (the IFAS vice president) about making off-site workshops a formal program and obtaining financial support from IFAS for UF Carpentries.
+* Geraldine will contact Jeanna (the IFAS vice president) about making off-site workshops a formal program and obtaining financial support from IFAS for UF Carpentries.
 
 ## Update on Emerging Pathogens Institute (EPI) workshop
 * Geraldine gave a brief update after her meeting with the two organizers (Carla Mavini and Taylor Paisie).
+* They wanted to be involved in teaching themselves, and have looked at the current genomics curriculum to see what’s relevant. R is not in genetics component; the R component isn’t finalized, and the timing not worked out.
+* They want visualizations; at least 1 person who is certified (?), want small bit on HPC but no overlap with HPC workshops.
+* They don’t seem to want to run it themselves.
 
 ### Next meeting
 * Will be Jan 22.


### PR DESCRIPTION
At this week's Board meeting, the Board decided to make a few corrections to the [previous meeting's minutes](https://www.uf-carpentries.org/minutes/board-2019-01-08/). They are made here.