### PR TITLE
Add Facebook group to social media icons on the front page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -108,7 +108,7 @@ author:
   codepen          :
   dribbble         :
   flickr           :
-  facebook         :
+  facebook         : "groups/322971701740318/"
   foursquare       :
   github           :
   gitlab           :

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@ training:
 intro: 
   - excerpt: 'Get notified about future workshops and events!<br />
   [<i class="fab fa-twitter"></i> @UFCarpentries](https://twitter.com/UFCarpentries){: .btn .btn--twitter} <br />
+  [<i class="fab fa-facebook"></i> UF Carpentries Club](https://www.facebook.com/groups/322971701740318/){: .btn .btn--facebook} <br />
   [<i class="fas fa-fw fa-envelope-square" aria-hidden="true"></i> Mailing List](https://lists.ufl.edu/cgi-bin/wa?A0=INFORMATICS-TEACHING-L){: .btn .btn--primary}'
 feature_row:
   - image_path: /assets/images/feature_about.jpg

--- a/index.html
+++ b/index.html
@@ -11,9 +11,9 @@ training:
   - excerpt: 'Sign Ups are open for our upcoming [instructor training](https://www.uf-carpentries.org/training/) (April 08-09, 2019)!'
 intro: 
   - excerpt: 'Get notified about future workshops and events!<br />
-  [<i class="fab fa-twitter"></i> @UFCarpentries](https://twitter.com/UFCarpentries){: .btn .btn--twitter} <br />
-  [<i class="fab fa-facebook"></i> UF Carpentries Club](https://www.facebook.com/groups/322971701740318/){: .btn .btn--facebook} <br />
-  [<i class="fas fa-fw fa-envelope-square" aria-hidden="true"></i> Mailing List](https://lists.ufl.edu/cgi-bin/wa?A0=INFORMATICS-TEACHING-L){: .btn .btn--primary}'
+  [<i class="fas fa-fw fa-envelope-square" aria-hidden="true"></i> Mailing List](https://lists.ufl.edu/cgi-bin/wa?A0=INFORMATICS-TEACHING-L){: .btn .btn--primary}{:target="_blank"}
+  [<i class="fab fa-facebook"></i> UF Carpentries Club](https://www.facebook.com/groups/322971701740318/){: .btn .btn--facebook}{:target="_blank"}
+  [<i class="fab fa-twitter"></i> @UFCarpentries](https://twitter.com/UFCarpentries){: .btn .btn--twitter}{:target="_blank"}'
 feature_row:
   - image_path: /assets/images/feature_about.jpg
     alt: "2018 June 19 board meeting with a drop-in from @thecarpentries Executive Committee"


### PR DESCRIPTION
This PR updates the front page to include a link to the Facebook group in additional to the existing Twitter account and mailing list. It also places those logos in the same row rather than one below the other, and makes those links open new windows rather than opening in the current window.