### PR TITLE
Add social media policy page

### DIFF
--- a/_pages/governance.md
+++ b/_pages/governance.md
@@ -31,6 +31,10 @@ The [club charter]({{ site.baseurl }}/charter/) describes the goals of our organ
 
 The fees from our workshops go towards supporting club activities and also as travel awards for instructors. Please see our [award policies]({{ site.baseurl }}/awards/) for more information.
 
+## Social Media Policies
+
+You can follow UF Carpentries Club on a number of social media websites, which we update as per our [social media policy]({{site.baseurl}}/governance/social-media).
+
 ## Elections
 
 Elections are held annually. The current and previous events are described on our [elections]({{ site.baseurl }}/elections/) page. 

--- a/_pages/social-media.md
+++ b/_pages/social-media.md
@@ -1,0 +1,14 @@
+---
+layout: single
+permalink: /governance/social-media
+title: Social media policies
+classes: wide
+toc: true
+---
+
+You can follow UF Carpentries on a number of social media websites.
+
+[<i class="fas fa-fw fa-envelope-square" aria-hidden="true"></i> Mailing List](https://lists.ufl.edu/cgi-bin/wa?A0=INFORMATICS-TEACHING-L){: .btn .btn--primary}{:target="_blank"}
+[<i class="fab fa-facebook"></i> UF Carpentries Club](https://www.facebook.com/groups/322971701740318/){: .btn .btn--facebook}{:target="_blank"}
+[<i class="fab fa-twitter"></i> @UFCarpentries](https://twitter.com/UFCarpentries){: .btn .btn--twitter}{:target="_blank"}
+

--- a/_pages/social-media.md
+++ b/_pages/social-media.md
@@ -15,7 +15,7 @@ You can follow UF Carpentries Club on a number of social media websites.
 
 ## Who runs this?
 
-Members of the [UF Carpentries Club board]({{site.baseurl}}/governance) serve as administrators on these social media websites.
+Members of the [UF Carpentries Club board]({{site.baseurl}}/governance) serve as administrators on these social media websites. We use [TweetDeck](https://tweetdeck.twitter.com/) to share access to our Twitter account. Currently, Hao and Gaurav have access to our Twitter account.
 
 ## How do we run it?
 
@@ -33,7 +33,7 @@ Content shared on our social media websites should follow the guidelines and cod
 3. Disparagement of people's work (say "X is awesome!" rather than "X is better than Y").
 4. Yourself (it's "we", not "I"!).
 
-### Guidelines
+### Content guidelines
 * Tag [@TheCarpentries](https://twitter.com/thecarpentries) or [@DataCarpentry](https://twitter.com/datacarpentry) when relevant.
 * Photos, images, animated gifs and emoji are encouraged.
 * Posts are expected to be casual, not formal. Formal posts should be written as a blog post on this website and posted to our social media platforms.

--- a/_pages/social-media.md
+++ b/_pages/social-media.md
@@ -7,7 +7,7 @@ toc: true
 ---
 
 You can follow UF Carpentries Club on a number of social media websites. 
-**If you are unhappy with anything we post to any of these platforms, please contact us [by email](mailto:ufcarpentries@gmail.com) or [open an issue on Github](https://github.com/UF-Carpentry/Coordination/issues/new).**
+**If you have questions, concerns, or feedback you want to share with us about our posted content on any of these platforms, please contact us [by email](mailto:ufcarpentries@gmail.com) or [open an issue on Github](https://github.com/UF-Carpentry/Coordination/issues/new).**
 
 [<i class="fas fa-fw fa-envelope-square" aria-hidden="true"></i> Mailing List](https://lists.ufl.edu/cgi-bin/wa?A0=INFORMATICS-TEACHING-L){: .btn .btn--primary}{:target="_blank"}
 [<i class="fab fa-facebook"></i> UF Carpentries Club](https://www.facebook.com/groups/322971701740318/){: .btn .btn--facebook}{:target="_blank"}

--- a/_pages/social-media.md
+++ b/_pages/social-media.md
@@ -1,14 +1,40 @@
 ---
 layout: single
 permalink: /governance/social-media
-title: Social media policies
+title: Social Media Policies
 classes: wide
 toc: true
 ---
 
-You can follow UF Carpentries on a number of social media websites.
+You can follow UF Carpentries Club on a number of social media websites. 
+**If you are unhappy with anything we post to any of these platforms, please contact us [by email](mailto:ufcarpentries@gmail.com) or [open an issue on Github](https://github.com/UF-Carpentry/Coordination/issues/new).**
 
 [<i class="fas fa-fw fa-envelope-square" aria-hidden="true"></i> Mailing List](https://lists.ufl.edu/cgi-bin/wa?A0=INFORMATICS-TEACHING-L){: .btn .btn--primary}{:target="_blank"}
 [<i class="fab fa-facebook"></i> UF Carpentries Club](https://www.facebook.com/groups/322971701740318/){: .btn .btn--facebook}{:target="_blank"}
 [<i class="fab fa-twitter"></i> @UFCarpentries](https://twitter.com/UFCarpentries){: .btn .btn--twitter}{:target="_blank"}
 
+## Who runs this?
+
+Members of the [UF Carpentries Club board]({{site.baseurl}}/governance) serve as administrators on these social media websites.
+
+## How do we run it?
+
+Content shared on our social media websites should follow the guidelines and code of conduct below. These are based on the policies of [R-Ladies Social Media Guide](https://github.com/rladies/starter-kit/blob/9b7caa0e55789a2b416a3b8041ee5ea7fb8055d9/Social_Media_Guide_for_Chapters.pdf).
+
+### Do promote
+1. Announcements and events organized by the Club.
+2. Educational materials that might be useful to Carpentry students or trainers.
+3. Local events that might be of interest to Carpentry students or trainers.
+4. Humourous content related to Carpentry courses.
+
+### Don't promote
+1. Specific political organizations or positions, unless they have been specifically endorsed by the UF Carpentries Club board.
+2. Commercial products or services.
+3. Disparagement of people's work (say "X is awesome!" rather than "X is better than Y").
+4. Yourself (it's "we", not "I"!).
+
+### Guidelines
+* Tag [@TheCarpentries](https://twitter.com/thecarpentries) or [@DataCarpentry](https://twitter.com/datacarpentry) when relevant.
+* Photos, images, animated gifs and emoji are encouraged.
+* Posts are expected to be casual, not formal. Formal posts should be written as a blog post on this website and posted to our social media platforms.
+* All posts on our social media platforms must be in line with our [Code of Conduct]({{site.baseurl}}/code-of-conduct/).


### PR DESCRIPTION
This PR adds a page detailing our social media policy (as requested in UF-Carpentry/Coordination#105). There's probably additional guidelines we should add -- please suggest them here or point me to other social media policies that we could ~steal~ borrow from.