### PR TITLE
Added a blog post describing upcoming events

### DIFF
--- a/_posts/2019-08-05-upcoming-events.md
+++ b/_posts/2019-08-05-upcoming-events.md
@@ -1,0 +1,17 @@
+---
+layout: posts
+title: "Upcoming events"
+date: 2019-08-05
+toc: true
+toc_sticky: true
+---
+
+The UF Carpentries Club board has been hard at work this summer to prepare for events and workshops for 2019-2020. The Fall semester will be kicked off supporting the [**Gainesville Research Bazaar**](https://uf-carpentry.github.io/resbaz2019/gainesville/), also known as ResBaz, taking place 11-13 September 2019. This is a worldwide festival promoting digital literacy emerging at the center of modern research. This participatory event features a large variety of activities such as talks, panel discussions, coding clinics, demos, lightning talks, etc. It will be a great opportunity to learn, share and network! More information to follow soon.
+
+There are two workshops planned for the Fall semester: a **Data Carpentry workshop** in early October 2019, and a **Genomics Data Carpentry** workshop in November 2019. Check [the UF Carpentries website](/events/) to stay up-to-date with events, or sign up for the [UFII mailing list](https://lists.ufl.edu/cgi-bin/wa?A0=UFIIMEMEBERMAIL-L) to get notifications about dates and registration.
+
+The UF Carpentries Club board will be holding **elections** in September 2019: if you are interested in joining the team in organizing workshops and promoting digital literacy on campus, please consider running for a position. The website has all the [details of the Club's governance](/governance/), and will have a link to election information. Nomination forms will be available in August 2019. Finally, a call for proposals for **travel awards** will go out in early August 2019. If you are a Carpentries instructor and you have taught or helped at 2 or more workshops in the last 2 years, you are [eligible for a travel award](/awards/). The UF Carpentries Club will make forms and details available soon.
+
+For **Spring 2020** there will be an Instructor training, as usual, and the Club strategizing about what other workshops to organize (e.g. machine learning or the Carpentries' social sciences curriculum). If you have ideas or input, everyone is welcome at the Club's bi-weekly board meetings in the UFII conference room. Our next meeting will be on 6 August 2019 at 3.45 pm (contact us if you want to attend remotely using a Zoom link).
+
+For regular updates on UF Carpentries Club activities, check their website or sign up to the following mailing lists: [Discussion of teaching informatics skills mailing list](https://lists.ufl.edu/cgi-bin/wa?A0=INFORMATICS-TEACHING-L), [UFII member list](https://lists.ufl.edu/cgi-bin/wa?A0=UFIIMEMEBERMAIL-L) or the [R Users List](https://lists.ufl.edu/cgi-bin/wa?A0=R-USERS-L).


### PR DESCRIPTION
Added a blog post describing upcoming events over the next two semesters. This is a mirror of the blog post posted to the UFBI website at https://biodiversity.institute.ufl.edu/event/uf-carpentries-club-upcoming-events/.