### PR TITLE
Added a blog post for the 2018 member site report.

### DIFF
--- a/_posts/2018-09-30-carpentries-member-site-report.md
+++ b/_posts/2018-09-30-carpentries-member-site-report.md
@@ -1,0 +1,7 @@
+---
+layout: posts
+title: "2018 Carpentries Member Site Report"
+date: 2018-09-30
+---
+
+Every year, [The Carpentries](https://carpentries.org/) sends us a report of all events we organized in the past year. You can read [our 2018 report](https://docs.google.com/document/d/1rLmBKqkR2oYA8uyzo0osWrHV7N0n8wAk-D9wmpABFqk/edit?usp=sharing), which covers some of the events we organized between January 1, 2017 and August 31, 2018. By their estimates, at least 193 participants attended our workshops in these twenty months!


### PR DESCRIPTION
I've dated the blog post to the date of the report. Note that we link directly to the report on Google Docs rather than keeping a local copy in this repo. I think that's fine for this report, although we might want to consider long-term archives like Zenodo for more detailed reports in the future.

Closes UF-Carpentry/Coordination#69.